### PR TITLE
Add prefixify support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+DESTDIR =
+EPREFIX =
+
+completionsdir ?= ${EPREFIX}/usr/share/zsh/site
+completions = $(wildcard src/_*)
+
+POSTINST_SED = sed -i -e "s|@GENTOO_PORTAGE_EPREFIX@|${EPREFIX}|g"
+
+all:
+	@echo Nothing to compile.
+
+install:
+	install -d "$(DESTDIR)$(completionsdir)"
+	install -m0644 $(completions) "$(DESTDIR)$(completionsdir)"
+	$(POSTINST_SED) $(addprefix "$(DESTDIR)$(completionsdir)"/,$(notdir $(completions)))
+

--- a/src/_eselect
+++ b/src/_eselect
@@ -13,7 +13,7 @@ _eselect_env () {
       "noldconfig[Do not alter the ld.so cache or configuration]" && return 0
   fi
   _values "env options" $common_values \
-    'update[Collect environment variables from all scripts in /etc/env.d/]' && return 0
+    'update[Collect environment variables from all scripts]' && return 0
 }
 
 _eselect_binutils () {

--- a/src/_gentoo_packages
+++ b/src/_gentoo_packages
@@ -58,7 +58,7 @@ _parsesetsconf() {
 
 _gentoo_packages_update_installed_sets() {
   local sets
-  sets=($(</var/lib/portage/world_sets))
+  sets=($(<@GENTOO_PORTAGE_EPREFIX@/var/lib/portage/world_sets))
   if [[ ((${#sets} > 0)) ]]; then
      _wanted installed_sets expl 'installed set' compadd "$@" "${(o@)^sets}"
   fi
@@ -67,7 +67,7 @@ _gentoo_packages_update_installed_sets() {
 _gentoo_packages_update_available_sets() {
   local dirs dir sets_dir set sets sets_path sets_files
 
-  dirs=($(_gentoo_repos -o) /etc/portage /usr/share/portage/config)
+  dirs=($(_gentoo_repos -o) @GENTOO_PORTAGE_EPREFIX@/etc/portage @GENTOO_PORTAGE_EPREFIX@/usr/share/portage/config)
 
   for dir in ${(@)dirs}; do
     if [[ -d ${dir} ]]; then
@@ -104,10 +104,10 @@ _gentoo_packages_update_useflag(){
 _gentoo_packages_update_active_useflag(){
   local flags USE
   var=USE
-  [[ -z ${(P)var} && -r /etc/portage/make.conf ]] &&
-    local $var="$(. /etc/portage/make.conf 2>/dev/null; echo ${(P)var})"
-  [[ -z ${(P)var} && -r /etc/make.conf ]] &&
-    local $var="$(. /etc/make.conf 2>/dev/null; echo ${(P)var})"
+  [[ -z ${(P)var} && -r @GENTOO_PORTAGE_EPREFIX@/etc/portage/make.conf ]] &&
+    local $var="$(. @GENTOO_PORTAGE_EPREFIX@/etc/portage/make.conf 2>/dev/null; echo ${(P)var})"
+  [[ -z ${(P)var} && -r @GENTOO_PORTAGE_EPREFIX@/etc/make.conf ]] &&
+    local $var="$(. @GENTOO_PORTAGE_EPREFIX@/etc/make.conf 2>/dev/null; echo ${(P)var})"
   flags=(${${${=USE}%-*}%\\*})
   compadd $flags
 }
@@ -122,7 +122,7 @@ _gentoo_packages_update_category(){
 
 _gentoo_packages_update_installed(){
    local installed_dir installed_portage installed_pkgname installed_list
-   installed_dir="/var/db/pkg"
+   installed_dir="@GENTOO_PORTAGE_EPREFIX@/var/db/pkg"
    installed_portage=($installed_dir/*-*/*)
 
    installed_pkgname=(${${installed_portage:t}%%-[0-9]*})
@@ -135,7 +135,7 @@ _gentoo_packages_update_installed(){
 _gentoo_packages_update_installed_versions(){
   local installed_list installed_portage
 
-  installed_portage=(/var/db/pkg/*-*/*)
+  installed_portage=(@GENTOO_PORTAGE_EPREFIX@/var/db/pkg/*-*/*)
   _wanted packages expl 'package' compadd "$@" ${installed_portage:t}
 
   installed_list=(${installed_portage##*/pkg/})
@@ -196,12 +196,12 @@ _gentoo_packages_update_available_versions(){
 _gentoo_packages_update_binary() {
   local PKGDIR
 
-  [[ -z $PKGDIR && -r /etc/portage/make.conf ]] &&
-    PKGDIR="$(. /etc/portage/make.conf 2>/dev/null; echo $PKGDIR)"
-  [[ -z $PKGDIR && -r /etc/make.conf ]] &&
-    PKGDIR="$(. /etc/make.conf 2>/dev/null; echo $PKGDIR)"
-  [[ -z $PKGDIR && -r /usr/share/portage/config/make.globals ]] &&
-    PKGDIR="$(. /usr/share/portage/config/make.globals 2>/dev/null; echo $PKGDIR)"
+  [[ -z $PKGDIR && -r @GENTOO_PORTAGE_EPREFIX@/etc/portage/make.conf ]] &&
+    PKGDIR="$(. @GENTOO_PORTAGE_EPREFIX@/etc/portage/make.conf 2>/dev/null; echo $PKGDIR)"
+  [[ -z $PKGDIR && -r @GENTOO_PORTAGE_EPREFIX@/etc/make.conf ]] &&
+    PKGDIR="$(. @GENTOO_PORTAGE_EPREFIX@/etc/make.conf 2>/dev/null; echo $PKGDIR)"
+  [[ -z $PKGDIR && -r @GENTOO_PORTAGE_EPREFIX@/usr/share/portage/config/make.globals ]] &&
+    PKGDIR="$(. @GENTOO_PORTAGE_EPREFIX@/usr/share/portage/config/make.globals 2>/dev/null; echo $PKGDIR)"
 
   # this doesn't take care of ${PORTAGE_BINHOST}. If Gentoo official
   # binary mirror will be available we should rewrite it accordingly.

--- a/src/_gentoo_repos
+++ b/src/_gentoo_repos
@@ -11,7 +11,7 @@ _gentoo_repos() {
   overlay_paths=();
   result=();
 
-  if [[ -e /usr/share/portage/config/repos.conf || -e /etc/portage/repos.conf ]]; then
+  if [[ -e @GENTOO_PORTAGE_EPREFIX@/usr/share/portage/config/repos.conf || -e @GENTOO_PORTAGE_EPREFIX@/etc/portage/repos.conf ]]; then
     main_repo=$(_repos_conf DEFAULT main-repo)
     main_repo_path=$(_repos_conf ${main_repo} location)
 
@@ -19,14 +19,14 @@ _gentoo_repos() {
       overlay_paths+=($(_repos_conf ${overlay} location))
     done
 
-    source /etc/make.conf 2>/dev/null
-    source /etc/portage/make.conf 2>/dev/null
+    source @GENTOO_PORTAGE_EPREFIX@/etc/make.conf 2>/dev/null
+    source @GENTOO_PORTAGE_EPREFIX@/etc/portage/make.conf 2>/dev/null
 
     overlay_paths+=(${(@)PORTDIR_OVERLAY})
   else
-    source /usr/share/portage/config/make.globals 2>/dev/null
-    source /etc/make.conf 2>/dev/null
-    source /etc/portage/make.conf 2>/dev/null
+    source @GENTOO_PORTAGE_EPREFIX@/usr/share/portage/config/make.globals 2>/dev/null
+    source @GENTOO_PORTAGE_EPREFIX@/etc/make.conf 2>/dev/null
+    source @GENTOO_PORTAGE_EPREFIX@/etc/portage/make.conf 2>/dev/null
 
     main_repo_path="${PORTDIR}"
     overlay_paths=(${(@)PORTDIR_OVERLAY})
@@ -48,9 +48,9 @@ _repos_conf() {
 
   secname=();
 
-  for file in /usr/share/portage/config/repos.conf \
-           /etc/portage/repos.conf \
-           /etc/portage/repos.conf/*.conf; do
+  for file in @GENTOO_PORTAGE_EPREFIX@/usr/share/portage/config/repos.conf \
+           @GENTOO_PORTAGE_EPREFIX@/etc/portage/repos.conf \
+           @GENTOO_PORTAGE_EPREFIX@/etc/portage/repos.conf/*.conf; do
 
     [[ -f ${file} ]] || continue
     insection=0

--- a/src/_gentoolkit
+++ b/src/_gentoolkit
@@ -204,7 +204,7 @@ _equery () {
           {size,s}'[print size of files contained in package]'
           {uses,u}'[display USE flags for package]'
           {which,w}'[print full path to ebuild for package]'
-          {has,a}'[list all packages matching ENVIRONMENT data stored in /var/db/pkg]'
+          {has,a}'[list all installed packages where specified KEY matches the specified VALUE]'
           {keywords,y}'[display keywords for specified PKG]'
           {meta,m}'[display metadata about PKG]'
         )
@@ -357,7 +357,7 @@ _glsa_id () {
   # will be low. May be we should display only the X previous GLSA,
   # or GLSA ids of the X last month.
   #
-  # start to look at /usr/lib/gentoolkit/pym/glsa.py if GLSA_DIR is still
+  # start to look at @GENTOO_PORTAGE_EPREFIX@/usr/lib/gentoolkit/pym/glsa.py if GLSA_DIR is still
   # PORTDIR + "metadata/glsa/"
   # and then get the list (it's only xml files in GLSA_DIR, easy!)
 

--- a/src/_portage_utils
+++ b/src/_portage_utils
@@ -98,7 +98,7 @@ case $service in
       {'(--repo)-R','(-R)--repo'}'[Display installed packages with repository]' \
       {'(--umap)-U','(-U)--umap'}'[Display installed packages with flags used]' \
       {'(--columns)-c','(-c)--columns'}'[Display column view]' \
-      '--show-debug[Show /usr/lib/debug files]' \
+      '--show-debug[Show debug files]' \
       {'(--exact)-e','(-e)--exact'}'[Exact match (only CAT/PN or PN without PV)]' \
       {'(--all)-a','(-a)--all'}'[Show every installed package]' \
       {'(--dir)-d','(-d)--dir'}'[Only show directories]' \
@@ -115,7 +115,7 @@ case $service in
       {'(--unlist)-u','(-u)--unlist'}'[Show unmerge history]' \
       {'(--sync)-s','(-s)--sync'}'[Show sync history]' \
       {'(--current)-c','(-c)--current'}'[Show current emerging packages]' \
-      {'(--logfile)-f','(-f)--logfile'}'[Read emerge logfile instead of /var/log/emerge.log]:log:_files' \
+      {'(--logfile)-f','(-f)--logfile'}'[Read emerge logfile instead of $EMERGE_LOG_DIR/emerge.log]:log:_files' \
       '*:packages:_gentoo_packages available'
     ;;
   qsearch)


### PR DESCRIPTION
Make zsh completion working in gentoo eprefix enviroment.

If accepted, we should file a bug for the ebuild repository (https://github.com/gentoo/gentoo).
(see
[gentoo-zsh-completions-99999999.ebuild-patch.txt](https://github.com/gentoo/gentoo-zsh-completions/files/1572120/gentoo-zsh-completions-99999999.ebuild-patch.txt)
 attachment)

