### PR TITLE
_eselect completion

### DIFF
--- a/src/_ekeyword
+++ b/src/_ekeyword
@@ -1,0 +1,23 @@
+#compdef ekeyword
+
+local -a arguments=(
+    '(- :)'{-h,--help}'[Show this help message and exit]'
+    '(-m --manifest)'{-m,--manifest}'[Run `ebuild manifest` on the ebuild after modifying it]'
+    '(-n --dry-run)'{-n,--dry-run}'[Show what would be changed, but do not commit]'
+    '(-v --verbose)'{-v,--verbose}'[Be verbose while processing things]'
+    '(-q --quiet)'{-q,--quiet}'[Be quiet while processing things (only show errors)]'
+    '(--format)'--format':Select output format for showing differences:_values -V ekeywordsfmt "ekeywords formats" auto color-inline inline short-multi long-multi'
+    '(- :)'{-V,--version}'[Show version information]'
+)
+
+(( $+functions[_ekeywordargs] )) ||  _ekeywordargs() {
+    _files -g \*.ebuild
+
+    local -a keywords=(all $(_gentoo_arches))
+
+    compset -P '(\^|\~)'
+    _values -V "keywords" "gentoo arches" ${keywords[@]}
+}
+
+_arguments ${arguments[@]} "*:ekeywordargs:_ekeywordargs"
+

--- a/src/_eselect
+++ b/src/_eselect
@@ -45,25 +45,24 @@ _eselect_parse_generic() {
 }
 
 _eselect_parse_action_list() {
-  local eselect_list
-  local idx descr
-  local arr_items_selected=$2
-  local arr_items_unselected=$3
+  local idx item tag
+  local -a _sel_items
+  local -a _unsel_items
 
-  eselect_list="$(LANG=C COLUMNS=100 eselect --colour=no $1 list 2> /dev/null)"
-  while IFS="" read -r ele ; do
-    echo "$ele" | read idx descr
-    idx=${idx#*\[}
-    idx=${idx%\]*}
-    if [[ "$idx" =~ '^[0-9]+$' ]]; then
-      local stripped_descr="${descr% *\**}"
-      if [[ "${stripped_descr}" != "${descr}" ]] ; then
-        set -A $arr_items_selected ${(P)arr_items_selected} "$idx:${(q)descr}"
-      else
-        set -A $arr_items_unselected ${(P)arr_items_unselected} "$idx:${(q)descr}"
-      fi
+  while read idx item tag ; do
+    if [[ "$idx" == '[' && "$item" == ']' ]] ; then
+      continue
     fi
-  done <<< "$eselect_list"
+    if [[ -z "$tag" ]] ; then
+      _unsel_items+=($item)
+    else
+      _sel_items+=($item)
+    fi
+  done <<< $(LANG=C COLUMNS=100 eselect --colour=no $1 list 2> /dev/null | tail -n +2)
+
+  set -A $2 ${_sel_items[@]}
+  set -A $3 ${_unsel_items[@]}
+
 }
 
 _eselect_module_action() {
@@ -78,9 +77,15 @@ _eselect_complete_action() {
   local actionname=$(_eselect_get_module)
   if (( $+functions[_eselect_complete_${actionname}_action] )) ; then
     _eselect_complete_${actionname}_action
-  else
-    _eselect_complete_action_generic ${actionname}
+    return 0
   fi
+
+  if (( $NORMARG + $(_eselect_action_index) == $CURRENT )) ; then
+    _eselect_complete_action_generic ${actionname}
+    return 0
+  fi
+
+  _nothing
 }
 
 _eselect_get_module() {
@@ -110,31 +115,29 @@ _eselect_module() {
   _eselect_parse_generic
 }
 
-_eselect_complete_action_generic() {
+(( $+function[_eselect_complete_action_generic] )) || _eselect_complete_action_generic() {
   local -a sel_items
   local -a unsel_items
 
-  if (( $NORMARG + $(_eselect_action_index) == $CURRENT )) ; then
-    case "$(_eselect_get_action)" in
-      ("set"|"enable"))
-        _eselect_parse_action_list $1 sel_items unsel_items
-          if (( $#unsel_items + $#sel_items > 0 )) ; then
-          _describe -t eselect_sel   -V 'eselect items' unsel_items
-          if (( $#unsel_items + $#sel_items < 10 )) ; then
-            _describe -t eselect_unsel -V 'eselect already selected items' sel_items
-          fi
-          return 0
+  case "$(_eselect_get_action)" in
+    ("set"|"enable"))
+      _eselect_parse_action_list $1 sel_items unsel_items
+      if (( $#unsel_items + $#sel_items > 0 )) ; then
+        _describe -t eselect_sel   -V 'eselect items' unsel_items
+        if (( $#unsel_items + $#sel_items < 10 )) ; then
+          _describe -t eselect_unsel -V 'eselect already selected items' sel_items
         fi
-        ;;
-      ("remove"|"disable"))
-        _eselect_parse_action_list $1 sel_items unsel_items
-        if [[ -n "${sel_items[@]}" ]] ; then
-          _describe  -V 'eselect items' sel_items
-          return 0
-        fi
-        ;;
-    esac
-  fi
+        return 0
+      fi
+      ;;
+    ("remove"|"disable"))
+      _eselect_parse_action_list $1 sel_items unsel_items
+      if [[ -n "${sel_items[@]}" ]] ; then
+        _describe  -V 'eselect items' sel_items
+        return 0
+      fi
+      ;;
+  esac
 
   _nothing
 }
@@ -145,15 +148,19 @@ _eselect_complete_action_generic() {
 
   case "$(_eselect_get_action)" in
     ("read"|"unread"))
-      local -a extra_items=('all:Read all news items')
+      items=('all:Read all news items')
       if [[ $(_eselect_get_action) == "read" ]] ; then
-        extra_items=('new:Read unread news items (default)' "${extra_items[@]}")
+        items+=('new:Read unread news items (default)' "${extra_items[@]}")
       fi
-      _eselect_parse_action_list news items items
 
-      items=(${(q)extra_items[@]} ${(Oa)items})
+      local idx descr
+      while read idx descr ; do
+        idx=${idx#'['}
+        idx=${idx%']'}
+        items+=(${idx}:${(q)descr})
+      done <<< $(eselect --colour=no news list 2> /dev/null | tail -n +2)
       if [[ -n "${items[@]}" ]] ; then
-        _describe  -V 'eselect items' items
+        _describe  -V 'eselect news' items
         return 0
       fi
       ;;
@@ -228,6 +235,10 @@ _eselect_complete_action_generic() {
   fi
 
   _nothing
+}
+
+(( $+functions[_eselect_complete_repository_action] )) || _eselect_complete_repository_action() {
+  _eselect_complete_action_generic repository
 }
 
 eselect_comp() {

--- a/src/_eselect
+++ b/src/_eselect
@@ -237,6 +237,31 @@ _eselect_module() {
   _nothing
 }
 
+(( $+functions[_eselect_complete_rc_action] )) || _eselect_complete_rc_action() {
+  if (( $NORMARG + $(_eselect_action_index) == $CURRENT )) ; then
+    case "$(_eselect_get_action)" in
+      ("list"|"show"))
+        _values 'runlevels' $(command ls --color=never ${EPREFIX}/etc/runlevels)
+        return 0
+        ;;
+      ("add"|"delete"|"pause"|"reload"|"restart"|"start"|"stop"))
+        _values 'scripts' $(rc-service -l)
+        return 0
+        ;;
+      esac
+  elif (( $NORMARG + $(_eselect_action_index) + 1 == $CURRENT )) ; then
+    case "$words[$CURRENT-2]" in
+      ("add"|"delete")
+        _values 'runlevels' $(command ls --color=never ${EPREFIX}/etc/runlevels)
+        return 0
+        ;;
+    esac
+  fi
+
+  _nothing
+}
+
+
 (( $+functions[_eselect_complete_repository_action] )) || _eselect_complete_repository_action() {
   _eselect_complete_action_generic repository
 }

--- a/src/_eselect
+++ b/src/_eselect
@@ -207,6 +207,29 @@ _eselect_complete_action_generic() {
   _nothing
 }
 
+(( $+functions[_eselect_complete_php_action] )) || _eselect_complete_php_action() {
+  if (( $NORMARG + $(_eselect_action_index) == $CURRENT )) ; then
+    case "$(_eselect_get_action)" in
+      ("list"|"set"|"show"|"update"))
+        _values 'eselect php modules' $(eselect --colour=no --brief php list-modules)
+        return 0
+        ;;
+    esac
+  elif (( $NORMARG + $(_eselect_action_index) + 1 == $CURRENT )) ; then
+    case "$words[$CURRENT-2]" in
+      "set")
+        local targets=($(eselect --colour=no --brief php list "$words[$CURRENT-1]" 2> /dev/null))
+        if [ -n "$targets" ]; then
+          _values 'eselect php modules'  ${targets[@]}
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  _nothing
+}
+
 eselect_comp() {
   integer NORMARG
 

--- a/src/_eselect
+++ b/src/_eselect
@@ -148,17 +148,17 @@ _eselect_module() {
 
   case "$(_eselect_get_action)" in
     ("read"|"unread"))
-      items=('all:Read all news items')
-      if [[ $(_eselect_get_action) == "read" ]] ; then
-        items+=('new:Read unread news items (default)' "${extra_items[@]}")
-      fi
-
       local idx descr
       while read idx descr ; do
         idx=${idx#'['}
         idx=${idx%']'}
-        items+=(${idx}:${(q)descr})
+        items=(${idx}:${(q)descr} ${items[@]})
       done <<< $(eselect --colour=no news list 2> /dev/null | tail -n +2)
+      items+=('all:Read all news items')
+      if [[ $(_eselect_get_action) == "read" ]] ; then
+        items+=('new:Read unread news items (default)')
+      fi
+
       if [[ -n "${items[@]}" ]] ; then
         _describe  -V 'eselect news' items
         return 0

--- a/src/_eselect
+++ b/src/_eselect
@@ -49,14 +49,14 @@ _eselect_parse_action_list() {
   local -a _sel_items
   local -a _unsel_items
 
-  while read idx item tag ; do
+  while read idx item tag descr ; do
     if [[ "$idx" == '[' && "$item" == ']' ]] ; then
       continue
     fi
-    if [[ -z "$tag" ]] ; then
-      _unsel_items+=($item)
-    else
+    if [[ ${tag} =~ '^[*@#]$' ]] ; then
       _sel_items+=($item)
+    else
+      _unsel_items+=($item)
     fi
   done <<< $(LANG=C COLUMNS=100 eselect --colour=no $1 list 2> /dev/null | tail -n +2)
 
@@ -251,7 +251,7 @@ _eselect_module() {
       esac
   elif (( $NORMARG + $(_eselect_action_index) + 1 == $CURRENT )) ; then
     case "$words[$CURRENT-2]" in
-      ("add"|"delete")
+      ("add"|"delete"))
         _values 'runlevels' $(command ls --color=never ${EPREFIX}/etc/runlevels)
         return 0
         ;;
@@ -263,6 +263,18 @@ _eselect_module() {
 
 
 (( $+functions[_eselect_complete_repository_action] )) || _eselect_complete_repository_action() {
+  local -a opts
+
+  case "$(_eselect_get_action)" in
+    ("disable"|"remove"))
+      opts=('-f:Force potentially dangerous removals')
+      ;;
+    "list")
+      opts=('-i:Only list installed')
+      ;;
+  esac
+
+  _describe -o 'options' opts
   _eselect_complete_action_generic repository
 }
 

--- a/src/_portage_utils
+++ b/src/_portage_utils
@@ -1,4 +1,4 @@
-#compdef qatom qcache qcheck qdepends qfile qgrep qlist qlop qpkg qsearch qsize qtbz2 quse qxpak
+#compdef qatom qcheck qdepends qfile qgrep qkeyword qlist qlop qmanifest qmerge qpkg qsearch qsize qtbz2 quse qxpak
 
 # portage-utils-0.53
 
@@ -16,15 +16,75 @@ common_args=(
 case $service in
   qatom)
     _arguments -s $common_args \
-      {'(--compare)-c','(-c)--compare'}'[Compare two atoms]'
+      {'(--format)-F','(-F)--format'}'[Custom output format]:format' \
+      {'(--compare)-c','(-c)--compare'}'[Compare two atoms]' \
+      {'(--print)-p','(-p)--print'}'[Print reconstructed atom]' \
+      '*:package-atom'
     ;;
-  qcache)
+  qcheck)
+    _arguments -s $common_args \
+      {'(--format)-F','(-F)--format'}'[Custom output format]:format' \
+      {'(--skip)-s','(-s)--skip'}'[Ignore files matching regular expression]:regex' \
+      {'(--update)-u','(-u)--update'}'[Update missing files, chksum and mtimes for packages]' \
+      {'(--noafk)-A','(-A)--noafk'}'[Ignore missing files]' \
+      {'(--badonly)-B','(-B)--badonly'}'[Only print pkgs containing bad files]' \
+      {'(--nohash)-H','(-H)--nohash'}'[Ignore differing/unknown file chksums]' \
+      {'(--nomtime)-T','(-T)--nomtime'}'[Ignore differing file mtimes]' \
+      {'(--skip-protected)-P','(-P)--skin-protected'}'[Ignore files in CONFIG_PROTECT-ed paths]' \
+      {'(--prelink)-p','(-p)--prelink'}'[Undo prelink when calculating checksums]' \
+      '*:packages:_gentoo_packages installed'
+    ;;
+  qdepends)
+    _arguments -s $common_args \
+      {'(--depend)-d','(-d)--depend'}'[Show DEPEND info]' \
+      {'(--rdepend)-r','(-r)--rdepend'}'[Show RDEPEND info]' \
+      {'(--pdepend)-p','(-p)--pdepend'}'[Show PDEPEND info]' \
+      {'(--bdepend)-b','(-b)--bdepend'}'[Show BDEPEND info]' \
+      {'(--query)-Q','(-Q)--query'}'[Query reverse deps]' \
+      {'(--installed)-i','(-i)--installed'}'[Search installed packages using VDB]' \
+      {'(--tree)-t','(-t)--tree'}'[Search available ebuilds in the tree]:packages:_gentoo_packages available' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
+      {'(--pretty)-S','(-S)--pretty'}'[Pretty format specified depend strings]' \
+      '*:packages:_gentoo_packages installed'
+    ;;
+  qfile)
+    _arguments -s $common_args \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]' \
+      {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots]' \
+      {'(--root-prefix)-R','(-R)--root-prefix'}'[Assume arguments are already prefixed by $ROOT]' \
+      {'(--dir)-d','(-d)--dir'}'[Also match directories for single component arguments]' \
+      {'(--orphans)-o','(-o)--orphans'}'[List orphan files]' \
+      {'(--exclude)-x','(-x)--exclude'}"[Don't look in package <arg> (used with --orphans)]:package:_gentoo_packages installed" \
+      '*:filename:_files'
+    ;;
+  qgrep)
+    _arguments -s $common_args \
+      {'(--invert-match)-I','(-I)--invert-match'}'[Select non-matching lines]' \
+      {'(--ignore-case)-i','(-i)--ignore-case'}'[Ignore case distinctions]' \
+      {'(--with-name)-N','(-N)--with-name'}'[Print the filename for each match]' \
+      {'(--count)-c','(-c)--count'}'[Only print a count of matching lines per FILE]' \
+      {'(--list)-l','(-l)--list'}'[Only print FILE names containing matches]' \
+      {'(--invert-list)-L','(-L)--invert-list'}'[Only print FILE names containing no match]' \
+      {'(--regexp)-e','(-e)--regexp'}'[Use PATTERN as a regular expression]' \
+      {'(--extended)-x','(-x)--extended'}'[Use PATTERN as an extended regular expression]' \
+      {'(--installed)-J','(-J)--installed'}'[Search in installed ebuilds instead of the tree]' \
+      {'(--eclass)-E','(-E)--eclass'}'[Search in eclasses instead of ebuilds]' \
+      {'(--skip-comments)-s','(-s)--skip-comments'}'[Skip comments lines]' \
+      {'(--repo)-R','(-R)--repo'}'[Print source repository name for each match (implies -N)]' \
+      {'(--skip)-S','(-S)--skip'}'[Skip lines matching <arg>]:pattern' \
+      {'(--before)-B','(-B)--before'}'[Print <arg> lines of leading context]:number' \
+      {'(--after)-A','(-A)--after'}'[Print <arg> lines of trailing context]:number' \
+      '*:pattern::'
+    ;;
+
+  qkeyword)
     local arches
     arches=( $(_gentoo_arches) )
 
     _arguments -s $common_args \
       {'(--matchpkg)-p','(-p)--matchpkg'}'[match pkgname]:package name:_gentoo_packages available_pkgnames_only' \
       {'(--matchcat)-c','(-c)--matchcat'}'[match catname]:category:_gentoo_packages category' \
+      {'(--matchmaint)-m','(-m)--matchmaint'}'[match maintainer email from metadata.xml (slow)]:email' \
       {'(--imlate)-i','(-i)--imlate'}'[list packages that can be marked stable on a given arch]' \
       {'(--dropped)-d','(-d)--dropped'}'[list packages that have dropped keywords on a version bump on a given arch]' \
       {'(--testing)-t','(-t)--testing'}'[list packages that have ~arch versions, but no stable versions on a given arch]' \
@@ -34,123 +94,94 @@ case $service in
 
       _describe -t available-arches "arch" arches
     ;;
-  qcheck)
-    _arguments -s $common_args \
-      {'(--all)-a','(-a)--all'}'[List all packages]' \
-      {'(--exact)-e','(-e)--exact'}'[Exact match (only CAT/PN or PN without PV)]' \
-      {'(--skip)-s','(-s)--skip'}'[Ignore files matching regular expression]:regex' \
-      {'(--update)-u','(-u)--update'}'[Update missing files, chksum and mtimes for packages]' \
-      {'(--noafk)-A','(-A)--noafk'}'[Ignore missing files]' \
-      {'(--badonly)-B','(-B)--badonly'}'[Only print pkgs containing bad files]' \
-      {'(--nohash)-H','(-H)--nohash'}'[Ignore differing/unknown file chksums]' \
-      {'(--nomtime)-T','(-T)--nomtime'}'[Ignore differing file mtimes]' \
-      '--skip-protected[Ignore files in CONFIG_PROTECT-ed paths]' \
-      {'(--prelink)-p','(-p)--prelink'}'[Undo prelink when calculating checksums]' \
-      '*:packages:_gentoo_packages installed'
-    ;;
-  qdepends)
-    _arguments -s $common_args \
-      {'(--depend)-d','(-d)--depend'}'[Show DEPEND info (default)]' \
-      {'(--rdepend)-r','(-r)--rdepend'}'[Show RDEPEND info]' \
-      {'(--pdepend)-p','(-p)--pdepend'}'[Show PDEPEND info]' \
-      {'(--key)-k','(-k)--key'}'[User defined vdb key]:vdb key' \
-      {'(--query)-Q','(-Q)--query'}'[Query reverse deps]' \
-      {'(--name-only)-N','(-N)--name-only'}'[Only show package name]' \
-      {'(--all)-a','(-a)--all'}'[Show all DEPEND info]' \
-      {'(--format)-f','(-f)--format'}'[Pretty format specified depend strings]' \
-      '*:packages:_gentoo_packages installed'
-    ;;
-  qfile)
-    _arguments -s $common_args \
-      {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots]' \
-      {'(--root-prefix)-R','(-R)--root-prefix'}'[Assume arguments are already prefixed by $ROOT]' \
-      {'(--from)-f','(-f)--from'}'[Read arguments from file <arg> ("-" for stdin)]' \
-      {'(--max-args)-m','(-m)--max-args'}'[Treat from file arguments by groups of <arg> (defaults to 5000)]:number' \
-      {'(--basename)-b','(-b)--basename'}'[Match any component of the path]' \
-      {'(--orphans)-o','(-o)--orphans'}'[List orphan files]' \
-      {'(--exclude)-x','(-x)--exclude'}"[Don't look in package <arg> (used with --orphans)]:package:_gentoo_packages installed" \
-      {'(--exact)-e','(-e)--exact'}'[Exact match (used with --exclude)]' \
-      '*:filename:_files'
-    ;;
-  qgrep)
-    _arguments -s $common_args \
-      {'(--invert-match)-I','(-I)--invert-match'}'[Select non-matching lines]' \
-      {'(--ignore-case)-i','(-i)--ignore-case'}'[Ignore case distinctions]' \
-      {'(--with-filename)-H','(-H)--with-filename'}'[Print the filename for each match]' \
-      {'(--with-name)-N','(-N)--with-name'}'[Print the package or eclass name for each match]' \
-      {'(--count)-c','(-c)--count'}'[Only print a count of matching lines per FILE]' \
-      {'(--list)-l','(-l)--list'}'[Only print FILE names containing matches]' \
-      {'(--invert-list)-L','(-L)--invert-list'}'[Only print FILE names containing no match]' \
-      {'(--regexp)-e','(-e)--regexp'}'[Use PATTERN as a regular expression]' \
-      {'(--extended)-x','(-x)--extended'}'[Use PATTERN as an extended regular expression]' \
-      {'(--installed)-J','(-J)--installed'}'[Search in installed ebuilds instead of the tree]' \
-      {'(--eclass)-E','(-E)--eclass'}'[Search in eclasses instead of ebuilds]' \
-      {'(--skip-comments)-s','(-s)--skip-comments'}'[Skip comments lines]' \
-      {'(--skip)-S','(-S)--skip'}'[Skip lines matching <arg>]:pattern' \
-      {'(--before)-B','(-B)--before'}'[Print <arg> lines of leading context]:number' \
-      {'(--after)-A','(-A)--after'}'[Print <arg> lines of trailing context]:number' \
-      '*:pattern::'
-    ;;
   qlist)
     _arguments -s $common_args \
       {'(--installed)-I','(-I)--installed'}'[Just show installed packages]' \
-      {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots]' \
+      {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots (use twice for subslots)]' \
       {'(--repo)-R','(-R)--repo'}'[Display installed packages with repository]' \
       {'(--umap)-U','(-U)--umap'}'[Display installed packages with flags used]' \
       {'(--columns)-c','(-c)--columns'}'[Display column view]' \
-      '--show-debug[Show debug files]' \
+      '--show-debug[Show /usr/lib/debug and /usr/src/debug files]' \
       {'(--exact)-e','(-e)--exact'}'[Exact match (only CAT/PN or PN without PV)]' \
       {'(--all)-a','(-a)--all'}'[Show every installed package]' \
       {'(--dir)-d','(-d)--dir'}'[Only show directories]' \
       {'(--obj)-o','(-o)--obj'}'[Only show objects]' \
       {'(--sym)-s','(-s)--sym'}'[Only show symlinks]' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:packages:_gentoo_packages installed'
     ;;
   qlop)
     _arguments -s $common_args \
-      {'(--gauge)-g','(-g)--gauge'}'[Gauge number of times a package has been merged]' \
-      {'(--time)-t','(-t)--time'}'[Calculate merge time for a specific package]' \
-      {'(--human)-H','(-H)--human'}'[Print seconds in human readable format (needs -t)]' \
-      {'(--list)-l','(-l)--list'}'[Show merge history]' \
-      {'(--unlist)-u','(-u)--unlist'}'[Show unmerge history]' \
+      {'(--summary)-c','(-c)--summary'}'[Print summary of average merges (implies -a)]' \
+      {'(--time()-t','(-t)--time'}'[Print time taken to complete action]' \
+      {'(--average)-a','(-a)--average'}'[Print average time taken to complete action]' \
+      {'(--human)-H','(-H)--human'}'[Print elapsed time in human readable format (use with -t or -a)]' \
+      {'(--machine)-M','(-M)--machine'}'[Print elapsed time as seconds with no formatting]' \
+      {'(--merge)-m','(-m)--merge'}'[Show merge history]' \
+      {'(--unmerge)-u','(-u)--unmerge'}'[Show unmerge history]' \
+      {'(--autoclean)-U','(-U)--autoclean'}'[Show autoclean unmerge history]' \
       {'(--sync)-s','(-s)--sync'}'[Show sync history]' \
-      {'(--current)-c','(-c)--current'}'[Show current emerging packages]' \
-      {'(--logfile)-f','(-f)--logfile'}'[Read emerge logfile instead of $EMERGE_LOG_DIR/emerge.log]:log:_files' \
+      {'(--endtime)-e','(-e)--endtime'}'[Report time at which the operation finished (iso started)]' \
+      {'(--running)-r','(-r)--running'}'[Show current emerging packages]' \
+      {'(--date)-d','(-d)--date'}'[Limit selection to this time (1st -d is start, 2nd -d is end)]:date' \
+      {'(--lastmerge)-l','(-l)--lastmerge'}'[Limit selection to last Portage emerge action]' \
+      {'(--logfile)-f','(-f)--logfile'}'[Read emerge logfile instead of $EMERGE_LOG_DIR/emerge.log]:filename:_files' \
+      {'(--atoms)-w','(-w)--atoms'}'[Read package atoms to report from file]:filename:_files' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:packages:_gentoo_packages available'
+    ;;
+  qmanifest)
+    _arguments -s $common_args \
+      {'(--generate)-g','(-g)--generate'}'[Generate thick Manifests]' \
+      {'(--signas)-s','(-s)--signas'}'[Sign generated Manifest using GPG key]:public key:_gpg public-keys' \
+      {'(--passphrase)-p','(-p)--passphrase'}'[Ask for GPG key password (instead of relying on gpg-agent)]' \
+      {'(--dir)-d','(-d)--dir'}'[Tread arguments as directories]:directory:_files -/' \
+      {'(--overlay)-o','(-o)--overlay'}'[Treat arguments as overlay names]:overlay:_gentoo_repos -o' \
+    ;;
+  qmerge)
+    _arguments -s $common_args \
+      {'(--fetch)-f','(-f)--fetch'}'[Fetch package and newest Packages metadata]' \
+      {'(--force)-F','(-F)--force'}'[Fetch package (skipping Packages)]' \
+      {'(--search)-s','(-s)--search'}'[Search available packages]' \
+      {'(--instal)-K','(-K)--install'}'[Install package]' \
+      {'(--unmerge)-U','(-U)--unmerge'}'[Uninstall package]' \
+      {'(--pretent)-p','(-p)--pretend'}'[Pretend only]' \
+      {'(--update)-u','(-u)--update'}'[Update only]' \
+      {'(--yes)-y','(-y)--yes'}"[Don't prompt before overwriting]" \
+      {'(--nodeps)-O','(-O)--nodeps'}"[Don't merge dependencies]" \
+      '--debug[Run shell funcs with `set -x`]' \
+      '*:packages:_gentoo_packages available'
+    ;;
+  qpkg)
+    _arguments -s $common_args \
+      {'(--clean)-c','(-c)--clean'}'[clean pkgdir of unused binary files]' \
+      {'(--eclean)-E','(-E)--eclean'}'[clean pkgdir of files not in the tree anymore (slow)]' \
+      {'(--pretend)-p','(-p)--pretend'}'[pretend only]' \
+      {'(--pkgdir)-P','(-P)--pkgdir'}'[alternate package directory]:alternate pkgdir:_files -/' \
+      '*:Installed packages:_gentoo_packages installed_versions'
     ;;
   qsearch)
     _arguments -s $common_args \
       {'(--all)-a','(-a)--all'}'[List the descriptions of every package in the cache]' \
-      {'(--cache)-c','(-c)--cache'}'[Use the portage cache]' \
-      {'(--ebuilds)-e','(-e)--ebuilds'}'[Use the portage ebuild tree]' \
       {'(--search)-s','(-s)--search'}'[Regex search package basenames]' \
-      {'(--desc)-S','(-S)--desc'}'[Regex search package descriptions]' \
+      {'(--desc)-S','(-S)--desc'}'[Regex search package descriptions (or homepage when using -H)]' \
       {'(--name-only)-N','(-N)--name-only'}'[Only show package name]' \
-      {'(--homepage)-H','(-H)--homepage'}'[Show homepage info]' \
+      {'(--homepage)-H','(-H)--homepage'}'[Show homepage info instead of description]' \
+      {'(--repo)-R','(-R)--repo'}'[Show repository the ebuild originates from]' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:pattern::'
     ;;
   qsize)
     _arguments -s $common_args \
       {'(--filesystem)-f','(-f)--filesystem'}'[Show size used on disk]' \
-      {'(--all)-a','(-a)--all'}'[Size all installed packages]' \
       {'(--sum)-s','(-s)--sum'}'[Include a summary]' \
       {'(--sum-only)-S','(-S)--sum-only'}'[Show just the summary]' \
       {'(--megabytes)-m','(-m)--megabytes'}'[Display size in megabytes]' \
       {'(--kilobytes)-k','(-k)--kilobytes'}'[Display size in kilobytes]' \
       {'(--bytes)-b','(-b)--bytes'}'[Display size in bytes]' \
       {'(--ignore)-i','(-i)--ignore'}'[Ignore regexp string]:pattern' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:packages:_gentoo_packages installed'
-    ;;
-  quse)
-    _arguments -s $common_args \
-      {'(--exact)-e','(-e)--exact'}'[Show exact non regexp matching using strcmp]' \
-      {'(--all)-a','(-a)--all'}'[Show annoying things in IUSE]' \
-      {'(--keywords)-K','(-K)--keywords'}'[Use the KEYWORDS vs IUSE]' \
-      {'(--license)-L','(-L)--license'}'[Use the LICENSE vs IUSE]' \
-      {'(--describe)-D','(-D)--describe'}'[Describe the USE flag]' \
-      {'(--format)-F','(-F)--format'}'[Use your own variable formats: -F NAME=]:format' \
-      {'(--name-only)-N','(-N)--name-only'}'[Only show package name]' \
-      '*:use flag:_gentoo_packages useflag'
     ;;
   qtbz2)
     _arguments -s $common_args \
@@ -161,13 +192,17 @@ case $service in
       {'(--xpak)-x','(-x)--xpak'}'[Just split the xpak]:tbz2 file:_files -g \*.tbz2' \
       {'(--stdout)-O','(-O)--stdout'}'[Write files to stdout]'
     ;;
-  qpkg)
+  quse)
     _arguments -s $common_args \
-      {'(--clean)-c','(-c)--clean'}'[clean pkgdir of unused binary files]' \
-      {'(--eclean)-E','(-E)--eclean'}'[clean pkgdir of files not in the tree anymore (slow)]' \
-      {'(--pretend)-p','(-p)--pretend'}'[pretend only]' \
-      {'(--pkgdir)-P','(-P)--pkgdir'}'[alternate package directory]:alternate pkgdir:_files -/' \
-      '*:Installed packages:_gentoo_packages installed_versions'
+      {'(--exact)-e','(-e)--exact'}'[Show exact non regexp matching using strcmp]' \
+      {'(--all)-a','(-a)--all'}"[List all ebuilds, don't match anything]" \
+      {'(--license)-L','(-L)--license'}'[Use the LICENSE vs IUSE]' \
+      {'(--describe)-D','(-D)--describe'}'[Describe the USE flag]' \
+      {'(--installed)-I','(-I)--installed'}'[Only search installed packages]' \
+      {'(--package)-p','(-p)--package'}'[Restrict matching to package or category]:package:gentoo_packages available' \
+      {'(--repo)-R','(-R)--repo'}'[Show repository the ebuild originates from]' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
+      '*:useflag:_gentoo_packages useflag'
     ;;
   qxpak)
     _arguments -s $common_args \


### PR DESCRIPTION
- add completion for the `php` module (does not follow the standard `set/list` way)
- switched to `_values`, which performs better while completing a large amount (i.e. `eselect fontconfig/repos`) and is more obvious on commandline[history], since the `news` module is the only one i've seen so far that *need* numbers as argument (which has already been treated seperately)