### PR TITLE
Update portage-utils completion 

### DIFF
--- a/src/_portage_utils
+++ b/src/_portage_utils
@@ -134,7 +134,7 @@ case $service in
     _arguments -s $common_args \
       {'(--generate)-g','(-g)--generate'}'[Generate thick Manifests]' \
       {'(--signas)-s','(-s)--signas'}'[Sign generated Manifest using GPG key]:public key:_gpg public-keys' \
-      {'(--passphrase)-p','{-p}--passphrase'}'[Ask for GPG key password (instead of relying on gpg-agent)]' \
+      {'(--passphrase)-p','(-p)--passphrase'}'[Ask for GPG key password (instead of relying on gpg-agent)]' \
       {'(--dir)-d','(-d)--dir'}'[Tread arguments as directories]:directory:_files -/' \
       {'(--overlay)-o','(-o)--overlay'}'[Treat arguments as overlay names]:overlay:_gentoo_repos -o' \
     ;;

--- a/src/_portage_utils
+++ b/src/_portage_utils
@@ -1,4 +1,4 @@
-#compdef qatom qcache qcheck qdepends qfile qgrep qlist qlop qpkg qsearch qsize qtbz2 quse qxpak
+#compdef qatom qcheck qdepends qfile qgrep qkeyword qlist qlop qmanifest qmerge qpkg qsearch qsize qtbz2 quse qxpak
 
 # portage-utils-0.53
 
@@ -16,68 +16,52 @@ common_args=(
 case $service in
   qatom)
     _arguments -s $common_args \
-      {'(--compare)-c','(-c)--compare'}'[Compare two atoms]'
-    ;;
-  qcache)
-    local arches
-    arches=( $(_gentoo_arches) )
-
-    _arguments -s $common_args \
-      {'(--matchpkg)-p','(-p)--matchpkg'}'[match pkgname]:package name:_gentoo_packages available_pkgnames_only' \
-      {'(--matchcat)-c','(-c)--matchcat'}'[match catname]:category:_gentoo_packages category' \
-      {'(--imlate)-i','(-i)--imlate'}'[list packages that can be marked stable on a given arch]' \
-      {'(--dropped)-d','(-d)--dropped'}'[list packages that have dropped keywords on a version bump on a given arch]' \
-      {'(--testing)-t','(-t)--testing'}'[list packages that have ~arch versions, but no stable versions on a given arch]' \
-      {'(--stats)-s','(-s)--stats'}'[display statistics about the portage tree]' \
-      {'(--all)-a','(-a)--all'}'[list packages that have at least one version keyworded for on a given arch]' \
-      {'(--not)-n','(-n)--not'}"[list packages that aren't keyworded on a given arch]"
-
-      _describe -t available-arches "arch" arches
+      {'(--format)-F','(-F)--format'}'[Custom output format]:format' \
+      {'(--compare)-c','(-c)--compare'}'[Compare two atoms]' \
+			{'(--print)-p','(-p)--print'}'[Print reconstructed atom]' \
+      '*:package-atom'
     ;;
   qcheck)
     _arguments -s $common_args \
-      {'(--all)-a','(-a)--all'}'[List all packages]' \
-      {'(--exact)-e','(-e)--exact'}'[Exact match (only CAT/PN or PN without PV)]' \
+      {'(--format)-F','(-F)--format'}'[Custom output format]:format' ''
       {'(--skip)-s','(-s)--skip'}'[Ignore files matching regular expression]:regex' \
       {'(--update)-u','(-u)--update'}'[Update missing files, chksum and mtimes for packages]' \
       {'(--noafk)-A','(-A)--noafk'}'[Ignore missing files]' \
       {'(--badonly)-B','(-B)--badonly'}'[Only print pkgs containing bad files]' \
       {'(--nohash)-H','(-H)--nohash'}'[Ignore differing/unknown file chksums]' \
       {'(--nomtime)-T','(-T)--nomtime'}'[Ignore differing file mtimes]' \
-      '--skip-protected[Ignore files in CONFIG_PROTECT-ed paths]' \
+      {'(--skip-protected)-P','(-P)--skin-protected'}'[Ignore files in CONFIG_PROTECT-ed paths]' \
       {'(--prelink)-p','(-p)--prelink'}'[Undo prelink when calculating checksums]' \
       '*:packages:_gentoo_packages installed'
     ;;
   qdepends)
     _arguments -s $common_args \
-      {'(--depend)-d','(-d)--depend'}'[Show DEPEND info (default)]' \
+      {'(--depend)-d','(-d)--depend'}'[Show DEPEND info]' \
       {'(--rdepend)-r','(-r)--rdepend'}'[Show RDEPEND info]' \
       {'(--pdepend)-p','(-p)--pdepend'}'[Show PDEPEND info]' \
-      {'(--key)-k','(-k)--key'}'[User defined vdb key]:vdb key' \
+      {'(--bdepend)-b','(-b)--bdepend'}'[Show BDEPEND info]' \
       {'(--query)-Q','(-Q)--query'}'[Query reverse deps]' \
-      {'(--name-only)-N','(-N)--name-only'}'[Only show package name]' \
-      {'(--all)-a','(-a)--all'}'[Show all DEPEND info]' \
-      {'(--format)-f','(-f)--format'}'[Pretty format specified depend strings]' \
+      {'(--installed)-i','(-i)--installed'}'[Search installed packages using VDB]' \
+      {'(--tree)-t','(-t)--tree'}'[Search available ebuilds in the tree]:packages:_gentoo_packages available' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
+      {'(--pretty)-S','(-S)--pretty'}'[Pretty format specified depend strings]' \
       '*:packages:_gentoo_packages installed'
     ;;
   qfile)
     _arguments -s $common_args \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]' \
       {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots]' \
       {'(--root-prefix)-R','(-R)--root-prefix'}'[Assume arguments are already prefixed by $ROOT]' \
-      {'(--from)-f','(-f)--from'}'[Read arguments from file <arg> ("-" for stdin)]' \
-      {'(--max-args)-m','(-m)--max-args'}'[Treat from file arguments by groups of <arg> (defaults to 5000)]:number' \
-      {'(--basename)-b','(-b)--basename'}'[Match any component of the path]' \
+      {'(--dir)-d','(-d)--dir'}'[Also match directories for single component arguments]' \
       {'(--orphans)-o','(-o)--orphans'}'[List orphan files]' \
       {'(--exclude)-x','(-x)--exclude'}"[Don't look in package <arg> (used with --orphans)]:package:_gentoo_packages installed" \
-      {'(--exact)-e','(-e)--exact'}'[Exact match (used with --exclude)]' \
       '*:filename:_files'
     ;;
   qgrep)
     _arguments -s $common_args \
       {'(--invert-match)-I','(-I)--invert-match'}'[Select non-matching lines]' \
       {'(--ignore-case)-i','(-i)--ignore-case'}'[Ignore case distinctions]' \
-      {'(--with-filename)-H','(-H)--with-filename'}'[Print the filename for each match]' \
-      {'(--with-name)-N','(-N)--with-name'}'[Print the package or eclass name for each match]' \
+      {'(--with-name)-N','(-N)--with-name'}'[Print the filename for each match]' \
       {'(--count)-c','(-c)--count'}'[Only print a count of matching lines per FILE]' \
       {'(--list)-l','(-l)--list'}'[Only print FILE names containing matches]' \
       {'(--invert-list)-L','(-L)--invert-list'}'[Only print FILE names containing no match]' \
@@ -86,70 +70,116 @@ case $service in
       {'(--installed)-J','(-J)--installed'}'[Search in installed ebuilds instead of the tree]' \
       {'(--eclass)-E','(-E)--eclass'}'[Search in eclasses instead of ebuilds]' \
       {'(--skip-comments)-s','(-s)--skip-comments'}'[Skip comments lines]' \
+      {'(--repo)-R','(-R)--repo'}'[Print source repository name for each match (implies -N)]' \
       {'(--skip)-S','(-S)--skip'}'[Skip lines matching <arg>]:pattern' \
       {'(--before)-B','(-B)--before'}'[Print <arg> lines of leading context]:number' \
       {'(--after)-A','(-A)--after'}'[Print <arg> lines of trailing context]:number' \
       '*:pattern::'
     ;;
+  qkeyword)
+    _arguments -s $common_args \
+      {'(--matchpkg)-p','(-p)--matchpkg'}'[match package name]:package:_gentoo_packages available' \
+      {'(--matchcat)-c','(-c)--matchcat'}'[match category name]:category:_gentoo_packages category' \
+      {'(--matchmaint)-m','(-m)--matchmaint'}'[match maintainer email from metadata.xml (slow)]:email' \
+      {'(--imlate)-i','(-i)--imlate'}'[list packages that can be marked stable on a given arch]' \
+      {'(--dropped)-d','(-d)--dropped'}'[list packages that have dropped keywords on a version bump on a given arch]' \
+      {'(--testing)-t','(-t)--testing'}'[list packages that have ~arch versions, but no stable versions on a given arch]' \
+      {'(--stats)-s','(-s)--stats'}'[display statistics about the portage tree]' \
+      {'(--all)-a','(-a)--all'}'[list packages that have at least one version keyworded for on a given arch]' \
+      {'(--not)-n','(-n)--not'}"[list packages that aren't keyworded on a given arch]" \
+      '*:arch:_gentoo_arches'
+
   qlist)
     _arguments -s $common_args \
       {'(--installed)-I','(-I)--installed'}'[Just show installed packages]' \
-      {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots]' \
+      {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots (use twice for subslots)]' \
       {'(--repo)-R','(-R)--repo'}'[Display installed packages with repository]' \
       {'(--umap)-U','(-U)--umap'}'[Display installed packages with flags used]' \
       {'(--columns)-c','(-c)--columns'}'[Display column view]' \
-      '--show-debug[Show debug files]' \
+      '--show-debug[Show /usr/lib/debug and /usr/src/debug files]' \
       {'(--exact)-e','(-e)--exact'}'[Exact match (only CAT/PN or PN without PV)]' \
       {'(--all)-a','(-a)--all'}'[Show every installed package]' \
       {'(--dir)-d','(-d)--dir'}'[Only show directories]' \
       {'(--obj)-o','(-o)--obj'}'[Only show objects]' \
       {'(--sym)-s','(-s)--sym'}'[Only show symlinks]' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:packages:_gentoo_packages installed'
     ;;
   qlop)
     _arguments -s $common_args \
-      {'(--gauge)-g','(-g)--gauge'}'[Gauge number of times a package has been merged]' \
-      {'(--time)-t','(-t)--time'}'[Calculate merge time for a specific package]' \
-      {'(--human)-H','(-H)--human'}'[Print seconds in human readable format (needs -t)]' \
-      {'(--list)-l','(-l)--list'}'[Show merge history]' \
-      {'(--unlist)-u','(-u)--unlist'}'[Show unmerge history]' \
+      {'(--summary)-c','(-c)--summary'}'[Print summary of average merges (implies -a)]' \
+      {'(--time()-t','(-t)--time'}'[Print time taken to complete action]' \
+      {'(--average)-a','(-a)--average'}'[Print average time taken to complete action]' \
+      {'(--human)-H','(-H)--human'}'[Print elapsed time in human readable format (use with -t or -a)]' \
+      {'(--machine)-M','(-M)--machine'}'[Print elapsed time as seconds with no formatting]' \
+      {'(--merge)-m','(-m)--merge'}'[Show merge history]' \
+      {'(--unmerge)-u','(-u)--unmerge'}'[Show unmerge history]' \
+      {'(--autoclean)-U','(-U)--autoclean'}'[Show autoclean unmerge history]' \
       {'(--sync)-s','(-s)--sync'}'[Show sync history]' \
-      {'(--current)-c','(-c)--current'}'[Show current emerging packages]' \
-      {'(--logfile)-f','(-f)--logfile'}'[Read emerge logfile instead of $EMERGE_LOG_DIR/emerge.log]:log:_files' \
+      {'(--endtime)-e','(-e)--endtime'}'[Report time at which the operation finished (iso started)]' \
+      {'(--running)-r','(-r)--running'}'[Show current emerging packages]' \
+      {'(--date)-d','(-d)--date'}'[Limit selection to this time (1st -d is start, 2nd -d is end)]:date' \
+      {'(--lastmerge)-l','(-l)--lastmerge'}'[Limit selection to last Portage emerge action]' \
+      {'(--logfile)-f','(-f)--logfile'}'[Read emerge logfile instead of $EMERGE_LOG_DIR/emerge.log]:filename:_files' \
+      {'(--atoms)-w','(-w)--atoms'}'[Read package atoms to report from file]:filename:_files' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
+      '*:packages:_gentoo_packages available'
+    ;;
+  qmanifest)
+    _arguments -s $common_args \
+      {'(--generate)-g','(-g)--generate'}'[Generate thick Manifests]' \
+      {'(--signas)-s','(-s)--signas'}'[Sign generated Manifest using GPG key]:public key:_gpg public-keys' \
+      {'(--passphrase)-p','{-p}--passphrase'}'[Ask for GPG key password (instead of relying on gpg-agent)]' \
+      {'(--dir)-d','(-d)--dir'}'[Tread arguments as directories]:directory:_files -/' \
+      {'(--overlay)-o','(-o)--overlay'}'[Treat arguments as overlay names]:overlay:_gentoo_repos -o' \
+    ;;
+  qmerge)
+    _arguments -s $common_args \
+      {'(--fetch)-f','(-f)--fetch'}'[Fetch package and newest Packages metadata]' \
+      {'(--force)-F','(-F)--force'}'[Fetch package (skipping Packages)]' \
+      {'(--search)-s','(-s)--search'}'[Search available packages]' \
+      {'(--instal)-K','(-K)--install'}'[Install package]' \
+      {'(--unmerge)-U','(-U)--unmerge'}'[Uninstall package]' \
+      {'(--pretent)-p','(-p)--pretend'}'[Pretend only]' \
+      {'(--update)-u','(-u)--update'}'[Update only]' \
+      {'(--yes)-y','(-y)--yes'}"[Don't prompt before overwriting]" \
+      {'(--nodeps)-O','(-O)--nodeps'}"[Don't merge dependencies]" \
+      '--debug[Run shell funcs with `set -x`]' \
       '*:packages:_gentoo_packages available'
     ;;
   qsearch)
     _arguments -s $common_args \
       {'(--all)-a','(-a)--all'}'[List the descriptions of every package in the cache]' \
-      {'(--cache)-c','(-c)--cache'}'[Use the portage cache]' \
-      {'(--ebuilds)-e','(-e)--ebuilds'}'[Use the portage ebuild tree]' \
       {'(--search)-s','(-s)--search'}'[Regex search package basenames]' \
-      {'(--desc)-S','(-S)--desc'}'[Regex search package descriptions]' \
+      {'(--desc)-S','(-S)--desc'}'[Regex search package descriptions (or homepage when using -H)]' \
       {'(--name-only)-N','(-N)--name-only'}'[Only show package name]' \
-      {'(--homepage)-H','(-H)--homepage'}'[Show homepage info]' \
+      {'(--homepage)-H','(-H)--homepage'}'[Show homepage info instead of description]' \
+      {'(--repo)-R','(-R)--repo'}'[Show repository the ebuild originates from]' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:pattern::'
     ;;
   qsize)
     _arguments -s $common_args \
       {'(--filesystem)-f','(-f)--filesystem'}'[Show size used on disk]' \
-      {'(--all)-a','(-a)--all'}'[Size all installed packages]' \
       {'(--sum)-s','(-s)--sum'}'[Include a summary]' \
       {'(--sum-only)-S','(-S)--sum-only'}'[Show just the summary]' \
       {'(--megabytes)-m','(-m)--megabytes'}'[Display size in megabytes]' \
       {'(--kilobytes)-k','(-k)--kilobytes'}'[Display size in kilobytes]' \
       {'(--bytes)-b','(-b)--bytes'}'[Display size in bytes]' \
       {'(--ignore)-i','(-i)--ignore'}'[Ignore regexp string]:pattern' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:packages:_gentoo_packages installed'
     ;;
   quse)
     _arguments -s $common_args \
       {'(--exact)-e','(-e)--exact'}'[Show exact non regexp matching using strcmp]' \
-      {'(--all)-a','(-a)--all'}'[Show annoying things in IUSE]' \
-      {'(--keywords)-K','(-K)--keywords'}'[Use the KEYWORDS vs IUSE]' \
+      {'(--all)-a','(-a)--all'}"[List all ebuilds, don't match anything]" \
       {'(--license)-L','(-L)--license'}'[Use the LICENSE vs IUSE]' \
       {'(--describe)-D','(-D)--describe'}'[Describe the USE flag]' \
-      {'(--format)-F','(-F)--format'}'[Use your own variable formats: -F NAME=]:format' \
-      {'(--name-only)-N','(-N)--name-only'}'[Only show package name]' \
+      {'(--installed)-I','(-I)--installed'}'[Only search installed packages]' \
+      {'(--package)-p'.'(-p)--package'}'[Restrict matching to package or category]:package:gentoo_packages available'
+      {'(--repo)-R','(-R)--repo'}'[Show repository the ebuild originates from]' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:use flag:_gentoo_packages useflag'
     ;;
   qtbz2)

--- a/src/_portage_utils
+++ b/src/_portage_utils
@@ -18,12 +18,12 @@ case $service in
     _arguments -s $common_args \
       {'(--format)-F','(-F)--format'}'[Custom output format]:format' \
       {'(--compare)-c','(-c)--compare'}'[Compare two atoms]' \
-			{'(--print)-p','(-p)--print'}'[Print reconstructed atom]' \
+      {'(--print)-p','(-p)--print'}'[Print reconstructed atom]' \
       '*:package-atom'
     ;;
   qcheck)
     _arguments -s $common_args \
-      {'(--format)-F','(-F)--format'}'[Custom output format]:format' ''
+      {'(--format)-F','(-F)--format'}'[Custom output format]:format' \
       {'(--skip)-s','(-s)--skip'}'[Ignore files matching regular expression]:regex' \
       {'(--update)-u','(-u)--update'}'[Update missing files, chksum and mtimes for packages]' \
       {'(--noafk)-A','(-A)--noafk'}'[Ignore missing files]' \
@@ -76,18 +76,23 @@ case $service in
       {'(--after)-A','(-A)--after'}'[Print <arg> lines of trailing context]:number' \
       '*:pattern::'
     ;;
+
   qkeyword)
+    local arches
+    arches=( $(_gentoo_arches) )
+
     _arguments -s $common_args \
-      {'(--matchpkg)-p','(-p)--matchpkg'}'[match package name]:package:_gentoo_packages available' \
-      {'(--matchcat)-c','(-c)--matchcat'}'[match category name]:category:_gentoo_packages category' \
+      {'(--matchpkg)-p','(-p)--matchpkg'}'[match pkgname]:package name:_gentoo_packages available_pkgnames_only' \
+      {'(--matchcat)-c','(-c)--matchcat'}'[match catname]:category:_gentoo_packages category' \
       {'(--matchmaint)-m','(-m)--matchmaint'}'[match maintainer email from metadata.xml (slow)]:email' \
       {'(--imlate)-i','(-i)--imlate'}'[list packages that can be marked stable on a given arch]' \
       {'(--dropped)-d','(-d)--dropped'}'[list packages that have dropped keywords on a version bump on a given arch]' \
       {'(--testing)-t','(-t)--testing'}'[list packages that have ~arch versions, but no stable versions on a given arch]' \
       {'(--stats)-s','(-s)--stats'}'[display statistics about the portage tree]' \
       {'(--all)-a','(-a)--all'}'[list packages that have at least one version keyworded for on a given arch]' \
-      {'(--not)-n','(-n)--not'}"[list packages that aren't keyworded on a given arch]" \
-      '*:arch:_gentoo_arches'
+      {'(--not)-n','(-n)--not'}"[list packages that aren't keyworded on a given arch]"
+
+      _describe -t available-arches "arch" arches
 
   qlist)
     _arguments -s $common_args \

--- a/src/_portage_utils
+++ b/src/_portage_utils
@@ -199,7 +199,7 @@ case $service in
       {'(--license)-L','(-L)--license'}'[Use the LICENSE vs IUSE]' \
       {'(--describe)-D','(-D)--describe'}'[Describe the USE flag]' \
       {'(--installed)-I','(-I)--installed'}'[Only search installed packages]' \
-      {'(--package)-p'.'(-p)--package'}'[Restrict matching to package or category]:package:gentoo_packages available'
+      {'(--package)-p','(-p)--package'}'[Restrict matching to package or category]:package:gentoo_packages available'
       {'(--repo)-R','(-R)--repo'}'[Show repository the ebuild originates from]' \
       {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:use flag:_gentoo_packages useflag'

--- a/src/_portage_utils
+++ b/src/_portage_utils
@@ -93,7 +93,7 @@ case $service in
       {'(--not)-n','(-n)--not'}"[list packages that aren't keyworded on a given arch]"
 
       _describe -t available-arches "arch" arches
-
+    ;;
   qlist)
     _arguments -s $common_args \
       {'(--installed)-I','(-I)--installed'}'[Just show installed packages]' \
@@ -199,10 +199,10 @@ case $service in
       {'(--license)-L','(-L)--license'}'[Use the LICENSE vs IUSE]' \
       {'(--describe)-D','(-D)--describe'}'[Describe the USE flag]' \
       {'(--installed)-I','(-I)--installed'}'[Only search installed packages]' \
-      {'(--package)-p','(-p)--package'}'[Restrict matching to package or category]:package:gentoo_packages available'
+      {'(--package)-p','(-p)--package'}'[Restrict matching to package or category]:package:gentoo_packages available' \
       {'(--repo)-R','(-R)--repo'}'[Show repository the ebuild originates from]' \
       {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
-      '*:use flag:_gentoo_packages useflag'
+      '*:useflag:_gentoo_packages useflag'
     ;;
   qxpak)
     _arguments -s $common_args \

--- a/src/_portage_utils
+++ b/src/_portage_utils
@@ -147,6 +147,14 @@ case $service in
       '--debug[Run shell funcs with `set -x`]' \
       '*:packages:_gentoo_packages available'
     ;;
+  qpkg)
+    _arguments -s $common_args \
+      {'(--clean)-c','(-c)--clean'}'[clean pkgdir of unused binary files]' \
+      {'(--eclean)-E','(-E)--eclean'}'[clean pkgdir of files not in the tree anymore (slow)]' \
+      {'(--pretend)-p','(-p)--pretend'}'[pretend only]' \
+      {'(--pkgdir)-P','(-P)--pkgdir'}'[alternate package directory]:alternate pkgdir:_files -/' \
+      '*:Installed packages:_gentoo_packages installed_versions'
+    ;;
   qsearch)
     _arguments -s $common_args \
       {'(--all)-a','(-a)--all'}'[List the descriptions of every package in the cache]' \
@@ -170,6 +178,15 @@ case $service in
       {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:packages:_gentoo_packages installed'
     ;;
+  qtbz2)
+    _arguments -s $common_args \
+      {'(--dir)-d','(-d)--dir'}'[Change to specified directory]:directory:_files -/' \
+      {'(--join)-j','(-j)--join'}'[Join tar.bz2 + xpak into a tbz2]:*:tar.bz2 file and xpak file:_files -g \*.\(tar.bz2\|xpak\)' \
+      {'(--split)-s','(-s)--split'}'[Split a tbz2 into a tar.bz2 + xpak]:tbz2 file:_files -g \*.tbz2' \
+      {'(--tarbz2)-t','(-t)--tarbz2'}'[Just split the tar.bz2]:tbz2 file:_files -g \*.tbz2' \
+      {'(--xpak)-x','(-x)--xpak'}'[Just split the xpak]:tbz2 file:_files -g \*.tbz2' \
+      {'(--stdout)-O','(-O)--stdout'}'[Write files to stdout]'
+    ;;
   quse)
     _arguments -s $common_args \
       {'(--exact)-e','(-e)--exact'}'[Show exact non regexp matching using strcmp]' \
@@ -181,23 +198,6 @@ case $service in
       {'(--repo)-R','(-R)--repo'}'[Show repository the ebuild originates from]' \
       {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:use flag:_gentoo_packages useflag'
-    ;;
-  qtbz2)
-    _arguments -s $common_args \
-      {'(--dir)-d','(-d)--dir'}'[Change to specified directory]:directory:_files -/' \
-      {'(--join)-j','(-j)--join'}'[Join tar.bz2 + xpak into a tbz2]:*:tar.bz2 file and xpak file:_files -g \*.\(tar.bz2\|xpak\)' \
-      {'(--split)-s','(-s)--split'}'[Split a tbz2 into a tar.bz2 + xpak]:tbz2 file:_files -g \*.tbz2' \
-      {'(--tarbz2)-t','(-t)--tarbz2'}'[Just split the tar.bz2]:tbz2 file:_files -g \*.tbz2' \
-      {'(--xpak)-x','(-x)--xpak'}'[Just split the xpak]:tbz2 file:_files -g \*.tbz2' \
-      {'(--stdout)-O','(-O)--stdout'}'[Write files to stdout]'
-    ;;
-  qpkg)
-    _arguments -s $common_args \
-      {'(--clean)-c','(-c)--clean'}'[clean pkgdir of unused binary files]' \
-      {'(--eclean)-E','(-E)--eclean'}'[clean pkgdir of files not in the tree anymore (slow)]' \
-      {'(--pretend)-p','(-p)--pretend'}'[pretend only]' \
-      {'(--pkgdir)-P','(-P)--pkgdir'}'[alternate package directory]:alternate pkgdir:_files -/' \
-      '*:Installed packages:_gentoo_packages installed_versions'
     ;;
   qxpak)
     _arguments -s $common_args \


### PR DESCRIPTION
- Update portage-utils completion to match options available in current stable release in tree '=app-portage/portage-utils-0.80'.

All q applets have an updated completion except q and qtegrity because:

- q is redundant for calling the individual applets.

- qtegrity is advanced kernel IMA verification stuff, which options I don't fully understand.