### PR TITLE
Update portage-utils completion (reopened - squashed - signed-off)

### DIFF
--- a/src/_portage_utils
+++ b/src/_portage_utils
@@ -1,6 +1,6 @@
-#compdef qatom qcache qcheck qdepends qfile qgrep qlist qlop qpkg qsearch qsize qtbz2 quse qxpak
+#compdef qatom qcheck qdepends qfile qgrep qkeyword qlist qlop qmanifest qmerge qpkg qsearch qsize qtbz2 quse qxpak
 
-# portage-utils-0.53
+# portage-utils-0.80
 
 local common_args
 
@@ -16,15 +16,75 @@ common_args=(
 case $service in
   qatom)
     _arguments -s $common_args \
-      {'(--compare)-c','(-c)--compare'}'[Compare two atoms]'
+      {'(--format)-F','(-F)--format'}'[Custom output format]:format' \
+      {'(--compare)-c','(-c)--compare'}'[Compare two atoms]' \
+      {'(--print)-p','(-p)--print'}'[Print reconstructed atom]' \
+      '*:package-atom'
     ;;
-  qcache)
+  qcheck)
+    _arguments -s $common_args \
+      {'(--format)-F','(-F)--format'}'[Custom output format]:format' \
+      {'(--skip)-s','(-s)--skip'}'[Ignore files matching regular expression]:regex' \
+      {'(--update)-u','(-u)--update'}'[Update missing files, chksum and mtimes for packages]' \
+      {'(--noafk)-A','(-A)--noafk'}'[Ignore missing files]' \
+      {'(--badonly)-B','(-B)--badonly'}'[Only print pkgs containing bad files]' \
+      {'(--nohash)-H','(-H)--nohash'}'[Ignore differing/unknown file chksums]' \
+      {'(--nomtime)-T','(-T)--nomtime'}'[Ignore differing file mtimes]' \
+      {'(--skip-protected)-P','(-P)--skin-protected'}'[Ignore files in CONFIG_PROTECT-ed paths]' \
+      {'(--prelink)-p','(-p)--prelink'}'[Undo prelink when calculating checksums]' \
+      '*:packages:_gentoo_packages installed'
+    ;;
+  qdepends)
+    _arguments -s $common_args \
+      {'(--depend)-d','(-d)--depend'}'[Show DEPEND info]' \
+      {'(--rdepend)-r','(-r)--rdepend'}'[Show RDEPEND info]' \
+      {'(--pdepend)-p','(-p)--pdepend'}'[Show PDEPEND info]' \
+      {'(--bdepend)-b','(-b)--bdepend'}'[Show BDEPEND info]' \
+      {'(--query)-Q','(-Q)--query'}'[Query reverse deps]' \
+      {'(--installed)-i','(-i)--installed'}'[Search installed packages using VDB]' \
+      {'(--tree)-t','(-t)--tree'}'[Search available ebuilds in the tree]:packages:_gentoo_packages available' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
+      {'(--pretty)-S','(-S)--pretty'}'[Pretty format specified depend strings]' \
+      '*:packages:_gentoo_packages installed'
+    ;;
+  qfile)
+    _arguments -s $common_args \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]' \
+      {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots]' \
+      {'(--root-prefix)-R','(-R)--root-prefix'}'[Assume arguments are already prefixed by $ROOT]' \
+      {'(--dir)-d','(-d)--dir'}'[Also match directories for single component arguments]' \
+      {'(--orphans)-o','(-o)--orphans'}'[List orphan files]' \
+      {'(--exclude)-x','(-x)--exclude'}"[Don't look in package <arg> (used with --orphans)]:package:_gentoo_packages installed" \
+      '*:filename:_files'
+    ;;
+  qgrep)
+    _arguments -s $common_args \
+      {'(--invert-match)-I','(-I)--invert-match'}'[Select non-matching lines]' \
+      {'(--ignore-case)-i','(-i)--ignore-case'}'[Ignore case distinctions]' \
+      {'(--with-name)-N','(-N)--with-name'}'[Print the filename for each match]' \
+      {'(--count)-c','(-c)--count'}'[Only print a count of matching lines per FILE]' \
+      {'(--list)-l','(-l)--list'}'[Only print FILE names containing matches]' \
+      {'(--invert-list)-L','(-L)--invert-list'}'[Only print FILE names containing no match]' \
+      {'(--regexp)-e','(-e)--regexp'}'[Use PATTERN as a regular expression]' \
+      {'(--extended)-x','(-x)--extended'}'[Use PATTERN as an extended regular expression]' \
+      {'(--installed)-J','(-J)--installed'}'[Search in installed ebuilds instead of the tree]' \
+      {'(--eclass)-E','(-E)--eclass'}'[Search in eclasses instead of ebuilds]' \
+      {'(--skip-comments)-s','(-s)--skip-comments'}'[Skip comments lines]' \
+      {'(--repo)-R','(-R)--repo'}'[Print source repository name for each match (implies -N)]' \
+      {'(--skip)-S','(-S)--skip'}'[Skip lines matching <arg>]:pattern' \
+      {'(--before)-B','(-B)--before'}'[Print <arg> lines of leading context]:number' \
+      {'(--after)-A','(-A)--after'}'[Print <arg> lines of trailing context]:number' \
+      '*:pattern::'
+    ;;
+
+  qkeyword)
     local arches
     arches=( $(_gentoo_arches) )
 
     _arguments -s $common_args \
       {'(--matchpkg)-p','(-p)--matchpkg'}'[match pkgname]:package name:_gentoo_packages available_pkgnames_only' \
       {'(--matchcat)-c','(-c)--matchcat'}'[match catname]:category:_gentoo_packages category' \
+      {'(--matchmaint)-m','(-m)--matchmaint'}'[match maintainer email from metadata.xml (slow)]:email' \
       {'(--imlate)-i','(-i)--imlate'}'[list packages that can be marked stable on a given arch]' \
       {'(--dropped)-d','(-d)--dropped'}'[list packages that have dropped keywords on a version bump on a given arch]' \
       {'(--testing)-t','(-t)--testing'}'[list packages that have ~arch versions, but no stable versions on a given arch]' \
@@ -34,123 +94,94 @@ case $service in
 
       _describe -t available-arches "arch" arches
     ;;
-  qcheck)
-    _arguments -s $common_args \
-      {'(--all)-a','(-a)--all'}'[List all packages]' \
-      {'(--exact)-e','(-e)--exact'}'[Exact match (only CAT/PN or PN without PV)]' \
-      {'(--skip)-s','(-s)--skip'}'[Ignore files matching regular expression]:regex' \
-      {'(--update)-u','(-u)--update'}'[Update missing files, chksum and mtimes for packages]' \
-      {'(--noafk)-A','(-A)--noafk'}'[Ignore missing files]' \
-      {'(--badonly)-B','(-B)--badonly'}'[Only print pkgs containing bad files]' \
-      {'(--nohash)-H','(-H)--nohash'}'[Ignore differing/unknown file chksums]' \
-      {'(--nomtime)-T','(-T)--nomtime'}'[Ignore differing file mtimes]' \
-      '--skip-protected[Ignore files in CONFIG_PROTECT-ed paths]' \
-      {'(--prelink)-p','(-p)--prelink'}'[Undo prelink when calculating checksums]' \
-      '*:packages:_gentoo_packages installed'
-    ;;
-  qdepends)
-    _arguments -s $common_args \
-      {'(--depend)-d','(-d)--depend'}'[Show DEPEND info (default)]' \
-      {'(--rdepend)-r','(-r)--rdepend'}'[Show RDEPEND info]' \
-      {'(--pdepend)-p','(-p)--pdepend'}'[Show PDEPEND info]' \
-      {'(--key)-k','(-k)--key'}'[User defined vdb key]:vdb key' \
-      {'(--query)-Q','(-Q)--query'}'[Query reverse deps]' \
-      {'(--name-only)-N','(-N)--name-only'}'[Only show package name]' \
-      {'(--all)-a','(-a)--all'}'[Show all DEPEND info]' \
-      {'(--format)-f','(-f)--format'}'[Pretty format specified depend strings]' \
-      '*:packages:_gentoo_packages installed'
-    ;;
-  qfile)
-    _arguments -s $common_args \
-      {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots]' \
-      {'(--root-prefix)-R','(-R)--root-prefix'}'[Assume arguments are already prefixed by $ROOT]' \
-      {'(--from)-f','(-f)--from'}'[Read arguments from file <arg> ("-" for stdin)]' \
-      {'(--max-args)-m','(-m)--max-args'}'[Treat from file arguments by groups of <arg> (defaults to 5000)]:number' \
-      {'(--basename)-b','(-b)--basename'}'[Match any component of the path]' \
-      {'(--orphans)-o','(-o)--orphans'}'[List orphan files]' \
-      {'(--exclude)-x','(-x)--exclude'}"[Don't look in package <arg> (used with --orphans)]:package:_gentoo_packages installed" \
-      {'(--exact)-e','(-e)--exact'}'[Exact match (used with --exclude)]' \
-      '*:filename:_files'
-    ;;
-  qgrep)
-    _arguments -s $common_args \
-      {'(--invert-match)-I','(-I)--invert-match'}'[Select non-matching lines]' \
-      {'(--ignore-case)-i','(-i)--ignore-case'}'[Ignore case distinctions]' \
-      {'(--with-filename)-H','(-H)--with-filename'}'[Print the filename for each match]' \
-      {'(--with-name)-N','(-N)--with-name'}'[Print the package or eclass name for each match]' \
-      {'(--count)-c','(-c)--count'}'[Only print a count of matching lines per FILE]' \
-      {'(--list)-l','(-l)--list'}'[Only print FILE names containing matches]' \
-      {'(--invert-list)-L','(-L)--invert-list'}'[Only print FILE names containing no match]' \
-      {'(--regexp)-e','(-e)--regexp'}'[Use PATTERN as a regular expression]' \
-      {'(--extended)-x','(-x)--extended'}'[Use PATTERN as an extended regular expression]' \
-      {'(--installed)-J','(-J)--installed'}'[Search in installed ebuilds instead of the tree]' \
-      {'(--eclass)-E','(-E)--eclass'}'[Search in eclasses instead of ebuilds]' \
-      {'(--skip-comments)-s','(-s)--skip-comments'}'[Skip comments lines]' \
-      {'(--skip)-S','(-S)--skip'}'[Skip lines matching <arg>]:pattern' \
-      {'(--before)-B','(-B)--before'}'[Print <arg> lines of leading context]:number' \
-      {'(--after)-A','(-A)--after'}'[Print <arg> lines of trailing context]:number' \
-      '*:pattern::'
-    ;;
   qlist)
     _arguments -s $common_args \
       {'(--installed)-I','(-I)--installed'}'[Just show installed packages]' \
-      {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots]' \
+      {'(--slots)-S','(-S)--slots'}'[Display installed packages with slots (use twice for subslots)]' \
       {'(--repo)-R','(-R)--repo'}'[Display installed packages with repository]' \
       {'(--umap)-U','(-U)--umap'}'[Display installed packages with flags used]' \
       {'(--columns)-c','(-c)--columns'}'[Display column view]' \
-      '--show-debug[Show debug files]' \
+      '--show-debug[Show /usr/lib/debug and /usr/src/debug files]' \
       {'(--exact)-e','(-e)--exact'}'[Exact match (only CAT/PN or PN without PV)]' \
       {'(--all)-a','(-a)--all'}'[Show every installed package]' \
       {'(--dir)-d','(-d)--dir'}'[Only show directories]' \
       {'(--obj)-o','(-o)--obj'}'[Only show objects]' \
       {'(--sym)-s','(-s)--sym'}'[Only show symlinks]' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:packages:_gentoo_packages installed'
     ;;
   qlop)
     _arguments -s $common_args \
-      {'(--gauge)-g','(-g)--gauge'}'[Gauge number of times a package has been merged]' \
-      {'(--time)-t','(-t)--time'}'[Calculate merge time for a specific package]' \
-      {'(--human)-H','(-H)--human'}'[Print seconds in human readable format (needs -t)]' \
-      {'(--list)-l','(-l)--list'}'[Show merge history]' \
-      {'(--unlist)-u','(-u)--unlist'}'[Show unmerge history]' \
+      {'(--summary)-c','(-c)--summary'}'[Print summary of average merges (implies -a)]' \
+      {'(--time()-t','(-t)--time'}'[Print time taken to complete action]' \
+      {'(--average)-a','(-a)--average'}'[Print average time taken to complete action]' \
+      {'(--human)-H','(-H)--human'}'[Print elapsed time in human readable format (use with -t or -a)]' \
+      {'(--machine)-M','(-M)--machine'}'[Print elapsed time as seconds with no formatting]' \
+      {'(--merge)-m','(-m)--merge'}'[Show merge history]' \
+      {'(--unmerge)-u','(-u)--unmerge'}'[Show unmerge history]' \
+      {'(--autoclean)-U','(-U)--autoclean'}'[Show autoclean unmerge history]' \
       {'(--sync)-s','(-s)--sync'}'[Show sync history]' \
-      {'(--current)-c','(-c)--current'}'[Show current emerging packages]' \
-      {'(--logfile)-f','(-f)--logfile'}'[Read emerge logfile instead of $EMERGE_LOG_DIR/emerge.log]:log:_files' \
+      {'(--endtime)-e','(-e)--endtime'}'[Report time at which the operation finished (iso started)]' \
+      {'(--running)-r','(-r)--running'}'[Show current emerging packages]' \
+      {'(--date)-d','(-d)--date'}'[Limit selection to this time (1st -d is start, 2nd -d is end)]:date' \
+      {'(--lastmerge)-l','(-l)--lastmerge'}'[Limit selection to last Portage emerge action]' \
+      {'(--logfile)-f','(-f)--logfile'}'[Read emerge logfile instead of $EMERGE_LOG_DIR/emerge.log]:filename:_files' \
+      {'(--atoms)-w','(-w)--atoms'}'[Read package atoms to report from file]:filename:_files' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:packages:_gentoo_packages available'
+    ;;
+  qmanifest)
+    _arguments -s $common_args \
+      {'(--generate)-g','(-g)--generate'}'[Generate thick Manifests]' \
+      {'(--signas)-s','(-s)--signas'}'[Sign generated Manifest using GPG key]:public key:_gpg public-keys' \
+      {'(--passphrase)-p','(-p)--passphrase'}'[Ask for GPG key password (instead of relying on gpg-agent)]' \
+      {'(--dir)-d','(-d)--dir'}'[Tread arguments as directories]:directory:_files -/' \
+      {'(--overlay)-o','(-o)--overlay'}'[Treat arguments as overlay names]:overlay:_gentoo_repos -o' \
+    ;;
+  qmerge)
+    _arguments -s $common_args \
+      {'(--fetch)-f','(-f)--fetch'}'[Fetch package and newest Packages metadata]' \
+      {'(--force)-F','(-F)--force'}'[Fetch package (skipping Packages)]' \
+      {'(--search)-s','(-s)--search'}'[Search available packages]' \
+      {'(--instal)-K','(-K)--install'}'[Install package]' \
+      {'(--unmerge)-U','(-U)--unmerge'}'[Uninstall package]' \
+      {'(--pretent)-p','(-p)--pretend'}'[Pretend only]' \
+      {'(--update)-u','(-u)--update'}'[Update only]' \
+      {'(--yes)-y','(-y)--yes'}"[Don't prompt before overwriting]" \
+      {'(--nodeps)-O','(-O)--nodeps'}"[Don't merge dependencies]" \
+      '--debug[Run shell funcs with `set -x`]' \
+      '*:packages:_gentoo_packages available'
+    ;;
+  qpkg)
+    _arguments -s $common_args \
+      {'(--clean)-c','(-c)--clean'}'[clean pkgdir of unused binary files]' \
+      {'(--eclean)-E','(-E)--eclean'}'[clean pkgdir of files not in the tree anymore (slow)]' \
+      {'(--pretend)-p','(-p)--pretend'}'[pretend only]' \
+      {'(--pkgdir)-P','(-P)--pkgdir'}'[alternate package directory]:alternate pkgdir:_files -/' \
+      '*:Installed packages:_gentoo_packages installed_versions'
     ;;
   qsearch)
     _arguments -s $common_args \
       {'(--all)-a','(-a)--all'}'[List the descriptions of every package in the cache]' \
-      {'(--cache)-c','(-c)--cache'}'[Use the portage cache]' \
-      {'(--ebuilds)-e','(-e)--ebuilds'}'[Use the portage ebuild tree]' \
       {'(--search)-s','(-s)--search'}'[Regex search package basenames]' \
-      {'(--desc)-S','(-S)--desc'}'[Regex search package descriptions]' \
+      {'(--desc)-S','(-S)--desc'}'[Regex search package descriptions (or homepage when using -H)]' \
       {'(--name-only)-N','(-N)--name-only'}'[Only show package name]' \
-      {'(--homepage)-H','(-H)--homepage'}'[Show homepage info]' \
+      {'(--homepage)-H','(-H)--homepage'}'[Show homepage info instead of description]' \
+      {'(--repo)-R','(-R)--repo'}'[Show repository the ebuild originates from]' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:pattern::'
     ;;
   qsize)
     _arguments -s $common_args \
       {'(--filesystem)-f','(-f)--filesystem'}'[Show size used on disk]' \
-      {'(--all)-a','(-a)--all'}'[Size all installed packages]' \
       {'(--sum)-s','(-s)--sum'}'[Include a summary]' \
       {'(--sum-only)-S','(-S)--sum-only'}'[Show just the summary]' \
       {'(--megabytes)-m','(-m)--megabytes'}'[Display size in megabytes]' \
       {'(--kilobytes)-k','(-k)--kilobytes'}'[Display size in kilobytes]' \
       {'(--bytes)-b','(-b)--bytes'}'[Display size in bytes]' \
       {'(--ignore)-i','(-i)--ignore'}'[Ignore regexp string]:pattern' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
       '*:packages:_gentoo_packages installed'
-    ;;
-  quse)
-    _arguments -s $common_args \
-      {'(--exact)-e','(-e)--exact'}'[Show exact non regexp matching using strcmp]' \
-      {'(--all)-a','(-a)--all'}'[Show annoying things in IUSE]' \
-      {'(--keywords)-K','(-K)--keywords'}'[Use the KEYWORDS vs IUSE]' \
-      {'(--license)-L','(-L)--license'}'[Use the LICENSE vs IUSE]' \
-      {'(--describe)-D','(-D)--describe'}'[Describe the USE flag]' \
-      {'(--format)-F','(-F)--format'}'[Use your own variable formats: -F NAME=]:format' \
-      {'(--name-only)-N','(-N)--name-only'}'[Only show package name]' \
-      '*:use flag:_gentoo_packages useflag'
     ;;
   qtbz2)
     _arguments -s $common_args \
@@ -161,13 +192,17 @@ case $service in
       {'(--xpak)-x','(-x)--xpak'}'[Just split the xpak]:tbz2 file:_files -g \*.tbz2' \
       {'(--stdout)-O','(-O)--stdout'}'[Write files to stdout]'
     ;;
-  qpkg)
+  quse)
     _arguments -s $common_args \
-      {'(--clean)-c','(-c)--clean'}'[clean pkgdir of unused binary files]' \
-      {'(--eclean)-E','(-E)--eclean'}'[clean pkgdir of files not in the tree anymore (slow)]' \
-      {'(--pretend)-p','(-p)--pretend'}'[pretend only]' \
-      {'(--pkgdir)-P','(-P)--pkgdir'}'[alternate package directory]:alternate pkgdir:_files -/' \
-      '*:Installed packages:_gentoo_packages installed_versions'
+      {'(--exact)-e','(-e)--exact'}'[Show exact non regexp matching using strcmp]' \
+      {'(--all)-a','(-a)--all'}"[List all ebuilds, don't match anything]" \
+      {'(--license)-L','(-L)--license'}'[Use the LICENSE vs IUSE]' \
+      {'(--describe)-D','(-D)--describe'}'[Describe the USE flag]' \
+      {'(--installed)-I','(-I)--installed'}'[Only search installed packages]' \
+      {'(--package)-p','(-p)--package'}'[Restrict matching to package or category]:package:gentoo_packages available' \
+      {'(--repo)-R','(-R)--repo'}'[Show repository the ebuild originates from]' \
+      {'(--format)-F','(-F)--format'}'[Print matched atom using given format string]:format' \
+      '*:useflag:_gentoo_packages useflag'
     ;;
   qxpak)
     _arguments -s $common_args \


### PR DESCRIPTION
Update portage-utils completion to match options available in current stable release in tree '=app-portage/portage-utils-0.80'.

All q applets have an updated completion except q and qtegrity because:

- q is redundant for calling the individual applets.

- qtegrity is advanced kernel IMA verification stuff, which options I don't fully understand.

Squashed commits and added 'signed-off-by' to commit