### PR TITLE
_gentoolkit: remove equery changes command completion

### DIFF
--- a/src/_gentoolkit
+++ b/src/_gentoolkit
@@ -92,15 +92,6 @@ _equery () {
                 '(-n --name-only)'{-n,--name-only}"[don't print the version]" \
                 '*:file:_files' && ret=0
               ;;
-            changes|c)
-              _arguments \
-                '(-l --latest)'{-l,--latest}'[only display latest ChangeLog entry]' \
-                '(-f --full)'{-f,--full}'[display full ChangeLog entry]' \
-                '--limit[limit the number of entries displayed (with --full)]:number:' \
-                '--from[which version to display from]' \
-                '--to[which version to display to]' \
-                ':portage:_packages available' && ret=0
-              ;;
             check|k)
               _arguments \
                 '(-f --full-regex)'{-f,--full-regex}'[supplied query is a regex]:pattern:' \
@@ -195,7 +186,6 @@ _equery () {
         tmp=(
           {belongs,b}'[list all packages owning file(s)]'
           {check,k}'[check MD5sums and timestamps of package]'
-          {changes,c}'[shows ChangeLog for specified package]'
           {depends,d}'[list all packages depending on specified package]'
           {depgraph,g}'[display a dependency tree for package]'
           {files,f}'[list files owned by package]'


### PR DESCRIPTION
it is removed since gentoolkit 0.6.0.
Closes: https://bugs.gentoo.org/945358